### PR TITLE
perf: reduce query counts for errata and osvariants. revisit mirror query

### DIFF
--- a/errata/views.py
+++ b/errata/views.py
@@ -29,7 +29,12 @@ from util.filterspecs import Filter, FilterBar
 
 @login_required
 def erratum_list(request):
-    errata = Erratum.objects.select_related()
+    errata = Erratum.objects.select_related() \
+        .prefetch_related('affected_packages',
+                          'fixed_packages',
+                          'osreleases',
+                          'cves',
+                          'references')
 
     if 'e_type' in request.GET:
         errata = errata.filter(e_type=request.GET['e_type']).distinct()

--- a/hosts/managers.py
+++ b/hosts/managers.py
@@ -47,6 +47,13 @@ class HostManager(models.Manager):
                 ),
                 0,
             ),
+            'get_num_errata': Coalesce(
+                Count(
+                    'errata',
+                    distinct=True,
+                ),
+                0,
+            ),
         }
 
         return self.get_queryset() \

--- a/hosts/models.py
+++ b/hosts/models.py
@@ -110,6 +110,9 @@ class Host(models.Model):
     def get_num_repos(self):
         return self.repos.count()
 
+    def get_num_errata(self):
+        return self.errata.count()
+
     def check_rdns(self):
         if self.check_dns:
             update_rdns(self)

--- a/hosts/templates/hosts/host_table.html
+++ b/hosts/templates/hosts/host_table.html
@@ -17,7 +17,7 @@
       <td><a href="{{ host.get_absolute_url }}">{{ host }}</a></td>
       <td class="centered" style="color:red">{% with count=host.get_num_security_updates %}{% if count != 0 %}{{ count }}{% else %}&nbsp;{% endif %}{% endwith %}</td>
       <td class="centered" style="color:orange">{% with count=host.get_num_bugfix_updates %}{% if count != 0 %}{{ count }}{% else %}&nbsp;{% endif %}{% endwith %}</td>
-      <td class="centered">{% with count=host.errata.count %}{% if count != 0 %}<a href="{% url 'errata:erratum_list' %}?host={{ host.hostname }}">{{ count }}{% else %}&nbsp;{% endif %}{% endwith %}<a/></td>
+      <td class="centered">{% with count=host.get_num_errata %}{% if count != 0 %}<a href="{% url 'errata:erratum_list' %}?host={{ host.hostname }}">{{ count }}{% else %}&nbsp;{% endif %}{% endwith %}<a/></td>
       <td>{{ host.kernel }}</td>
       <td><a href="{{ host.osvariant.get_absolute_url }}">{{ host.osvariant }}</a></td>
       <td>{{ host.lastreport }}{% report_alert host.lastreport %}</td>

--- a/hosts/views.py
+++ b/hosts/views.py
@@ -38,8 +38,9 @@ from hosts.serializers import HostSerializer, HostRepoSerializer
 @login_required
 def host_list(request):
     hosts = Host.objects.with_counts('get_num_security_updates',
-                                     'get_num_bugfix_updates') \
-            .select_related()
+                                     'get_num_bugfix_updates',
+                                     'get_num_errata') \
+            .select_related('osvariant__arch')
 
     if 'domain_id' in request.GET:
         hosts = hosts.filter(domain=request.GET['domain_id'])
@@ -97,7 +98,8 @@ def host_list(request):
     filter_list.append(Filter(request, 'Domain', 'domain_id', Domain.objects.all()))
     filter_list.append(Filter(request, 'OS Release', 'osrelease_id',
                               OSRelease.objects.filter(osvariant__host__in=hosts)))
-    filter_list.append(Filter(request, 'OS Variant', 'osvariant_id', OSVariant.objects.filter(host__in=hosts)))
+    filter_list.append(Filter(request, 'OS Variant', 'osvariant_id',
+                              OSVariant.objects.filter(host__in=hosts).select_related('arch')))
     filter_list.append(Filter(request, 'Architecture', 'arch_id', MachineArchitecture.objects.filter(host__in=hosts)))
     filter_list.append(Filter(request, 'Reboot Required', 'reboot_required', {'true': 'Yes', 'false': 'No'}))
     filter_bar = FilterBar(request, filter_list)

--- a/packages/views.py
+++ b/packages/views.py
@@ -117,7 +117,7 @@ def package_list(request):
 
 @login_required
 def package_name_list(request):
-    packages = PackageName.objects.select_related()
+    packages = PackageName.objects.select_related().prefetch_related('package_set')
 
     if 'arch_id' in request.GET:
         packages = packages.filter(package__arch=request.GET['arch_id']).distinct()

--- a/security/views.py
+++ b/security/views.py
@@ -70,7 +70,10 @@ def cwe_detail(request, cwe_id):
 
 @login_required
 def cve_list(request):
-    cves = CVE.objects.select_related()
+    cves = CVE.objects.select_related() \
+        .prefetch_related('cvss_scores',
+                          'cwes',
+                          'erratum_set')
 
     if 'erratum_id' in request.GET:
         cves = cves.filter(erratum=request.GET['erratum_id'])

--- a/util/views.py
+++ b/util/views.py
@@ -21,8 +21,7 @@ from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 
 from django.contrib.sites.models import Site
-from django.db.models import Count, Exists, F, OuterRef
-from django.db.models.functions import Coalesce
+from django.db.models import Exists, F, OuterRef
 
 from hosts.models import Host
 from operatingsystems.models import OSVariant, OSRelease
@@ -41,8 +40,9 @@ def dashboard(request):
         site = {'name': '', 'domainname': ''}
 
     hosts = Host.objects.with_counts('get_num_security_updates',
-                                     'get_num_bugfix_updates') \
-        .select_related()
+                                     'get_num_bugfix_updates',
+                                     'get_num_errata') \
+        .select_related('osvariant__arch')
     osvariants = OSVariant.objects.all().prefetch_related('host_set')
     osreleases = OSRelease.objects.all()
     repos = Repository.objects.all().prefetch_related('mirror_set')
@@ -104,10 +104,10 @@ def dashboard(request):
     possible_mirrors = {}
 
     mirrors = Mirror.objects.all() \
-        .annotate(packages_count=Coalesce(Count('packages', distinct=True), 0)) \
+        .filter(id__in=Package.objects.order_by().distinct().values_list('mirror', flat=True)) \
         .select_related()
     for mirror in mirrors:
-        if mirror.packages_checksum != 'yast' and mirror.packages_count > 0:
+        if mirror.packages_checksum != 'yast':
             if mirror.packages_checksum not in checksums:
                 checksums[mirror.packages_checksum] = []
             checksums[mirror.packages_checksum].append(mirror)


### PR DESCRIPTION
Gains:

| path | query count before | after |
| --- | --- | --- |
| `/dashboard/` | 842 | 26 |
| `/hosts/` | 431 | 9 |
| `/packages/` | 55 | 6 |
| `/errata/` | 256 | 11 |
| `/security/cves` | 154 | 7 |
